### PR TITLE
Fix bug when return is used instead of break

### DIFF
--- a/generate_csv.py
+++ b/generate_csv.py
@@ -338,7 +338,7 @@ class Filter(object):
                 if "branch" in branch.get_name():
                     # print "got here"
                     self.branch_conds.append(cond)
-                    return
+                    break
 
     def remove_call(self):
         """


### PR DESCRIPTION
Commit f6c195cba602288de22448c2643152ad74ba0f7a inserts
a return instead of break correcting pylint errors.
remove_non_branch function exits at first condition when
using return.

Signed-off-by: Cosmin-Gabriel Samoila <gabrielcsmo@gmail.com>